### PR TITLE
check for server.jar before downloading

### DIFF
--- a/server-config.sh
+++ b/server-config.sh
@@ -19,6 +19,8 @@ apt upgrade -y
 apt install git nginx openjdk-11-jdk-headless screen
 
 # install minecraft server
-curl https://launcher.mojang.com/v1/objects/1b557e7b033b583cd9f66746b7a9ab1ec1673ced/server.jar -o server.jar
+# download minecraft server if not already downloaded
+[[ ! -e server.jar ]] \
+  && curl https://launcher.mojang.com/v1/objects/1b557e7b033b583cd9f66746b7a9ab1ec1673ced/server.jar -o server.jar
 echo "eula=true" > eula.txt
 screen java -Xmx1024M -Xms1024M -jar server.jar nogui 

--- a/server-config.sh
+++ b/server-config.sh
@@ -20,7 +20,9 @@ apt install git nginx openjdk-11-jdk-headless screen
 
 # install minecraft server
 # download minecraft server if not already downloaded
-[[ ! -e server.jar ]] \
-  && curl https://launcher.mojang.com/v1/objects/1b557e7b033b583cd9f66746b7a9ab1ec1673ced/server.jar -o server.jar
+if [[ -e server.jar ]]
+  then echo "server.jar exists!"
+  else curl https://launcher.mojang.com/v1/objects/1b557e7b033b583cd9f66746b7a9ab1ec1673ced/server.jar -o server.jar
+fi
 echo "eula=true" > eula.txt
 screen java -Xmx1024M -Xms1024M -jar server.jar nogui 


### PR DESCRIPTION
Check for existence of the Minecraft server.jar file to prevent redundant downloads.